### PR TITLE
SakuliBootstrapDefaults

### DIFF
--- a/packages/sakuli-core/src/bootstrap/bootstrap-options.interface.ts
+++ b/packages/sakuli-core/src/bootstrap/bootstrap-options.interface.ts
@@ -8,3 +8,9 @@ export interface SakuliBootstrapOptions {
      */
     presetProvider: string[]
 }
+
+export const SakuliBootstrapDefaults = {
+    presetProvider: [
+        "@sakuli/legacy"
+    ]
+};

--- a/packages/sakuli-core/src/bootstrap/load-bootstrap-options.function.spec.ts
+++ b/packages/sakuli-core/src/bootstrap/load-bootstrap-options.function.spec.ts
@@ -1,13 +1,3 @@
-/*
-const mockFileMao
-
-jest.mock('fs-extra', () => ({
-    readJsonSync(path:string) {
-
-    }
-}))
-*/
-
 import mockFs from 'mock-fs';
 import {loadBootstrapOptions} from "./load-bootstrap-options.function";
 
@@ -23,13 +13,24 @@ describe('loadBootstrapOptions', () => {
                 })
             }
         });
-        const opts = await loadBootstrapOptions('root/')
+        const opts = await loadBootstrapOptions('root/');
         expect(opts.presetProvider.length).toBe(2);
+        expect(opts.presetProvider).toContain("p1");
+        expect(opts.presetProvider).toContain("p2");
+        done();
+    });
+
+    it('should load defaults when missing config', async done => {
+        mockFs({
+            root: {}
+        });
+        const opts = await loadBootstrapOptions('root/');
+        expect(opts.presetProvider.length).toBe(1);
+        expect(opts.presetProvider[0]).toBe("@sakuli/legacy");
         done();
     });
 
     afterEach(() => {
         mockFs.restore();
     })
-
 });

--- a/packages/sakuli-core/src/bootstrap/load-bootstrap-options.function.ts
+++ b/packages/sakuli-core/src/bootstrap/load-bootstrap-options.function.ts
@@ -1,8 +1,7 @@
 import {join} from "path";
-import {SakuliBootstrapOptions} from "./bootstrap-options.interface";
+import {SakuliBootstrapDefaults, SakuliBootstrapOptions} from "./bootstrap-options.interface";
 import {readJsonSync} from "fs-extra";
 import {ifPresent, Maybe} from "@sakuli/commons";
-import {inspect} from "util";
 
 /**
  * Reads sakuli bootconfiguration from a json file. The configuration is considered under a sakuli wich must implement the {@see SakuliBootstrapOptions} interface.*
@@ -23,12 +22,10 @@ export async function loadBootstrapOptions(path: string = '.', file: string = 'p
             conf = packageJson.sakuli
         }
     } catch (e) {
-
     }
+
     return ifPresent(conf,
         c => c,
-        () => ({
-            presetProvider: []
-        })
-        )
+        () => SakuliBootstrapDefaults
+    );
 }


### PR DESCRIPTION
I added default bootstrap options to run Sakuli without configuring a e.g. a preset provider.

I think this is a reasonable approach for opinionated, 'zero-config' test runs with fixed settings, more complex preset mechanisms should be addressed in a separate issue.