### PR TITLE
Bugfix/63/locate images

### DIFF
--- a/packages/sakuli-core/src/runner/sakuli-runner.class.ts
+++ b/packages/sakuli-core/src/runner/sakuli-runner.class.ts
@@ -30,13 +30,13 @@ export class SakuliRunner implements TestExecutionLifecycleHooks {
         });
         // onProject Phase
         await this.onProject(project, this.testExecutionContext);
-        const context = await this.requestContext(this.testExecutionContext, project);
         let result = {};
         await this.beforeExecution(project, this.testExecutionContext);
         for (const testFile of project.testFiles) {
             const testFileContent = await this.readFileContent(testFile, project, this.testExecutionContext);
             try {
                 await this.beforeRunFile(testFile, project, this.testExecutionContext);
+                const context = await this.requestContext(this.testExecutionContext, project);
                 const resultCtx = await this.testFileExecutor.execute(testFileContent.toString(), context, {
                     filename: resolve(join(project.rootDir, testFile.path)),
                     waitUntilDone: true

--- a/packages/sakuli-legacy/src/context/common/test-case.class.spec.ts
+++ b/packages/sakuli-legacy/src/context/common/test-case.class.spec.ts
@@ -1,0 +1,157 @@
+import {cwd} from "process";
+import {Project, TestExecutionContext} from "@sakuli/core";
+import {mockPartial} from "sneer";
+import {createTestCaseClass} from "./test-case.class";
+
+import nutConfig from "./nut-global-config.class";
+import {SimpleLogger} from "@sakuli/commons";
+import {join} from "path";
+import {ScreenApi} from "./actions/screen.function";
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+jest.mock("./actions/screen.function");
+ScreenApi.takeScreenshot = jest.fn();
+
+describe("TestCase", () => {
+
+    const testExecutionContext = mockPartial<TestExecutionContext>({
+        startTestStep: jest.fn(),
+        endTestStep: jest.fn(),
+        startTestCase: jest.fn(),
+        endTestCase: jest.fn(),
+        startTestSuite: jest.fn(),
+        getCurrentTestCase: jest.fn(),
+        updateCurrentTestCase: jest.fn(),
+        updateCurrentTestStep: jest.fn(),
+        startExecution: jest.fn(),
+        endExecution: jest.fn(),
+        getCurrentTestAction: jest.fn(),
+        getCurrentTestSuite: jest.fn(),
+        logger: mockPartial<SimpleLogger>({
+            info: jest.fn()
+        })
+    });
+
+    const project: Project = mockPartial<Project>({});
+
+    describe("image path", () => {
+        it("should throw on missing testcasefolder", () => {
+            // GIVEN
+            const SUT = createTestCaseClass(testExecutionContext, project, null);
+            // WHEN
+
+            // THEN
+            expect(() => new SUT("testId")).toThrowError("No testcase folder provided");
+        });
+
+        it("should use the CWD and the testcase folder for image search by default", () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+
+            // WHEN
+            new SUT("testId");
+
+            // THEN
+            expect(nutConfig.imagePaths.length).toBe(2);
+            expect(nutConfig.imagePaths).toContain(cwd());
+            expect(nutConfig.imagePaths).toContain(testFolder);
+        });
+
+        it("should treat relative path relative to testcase folder", () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const additionalRelativePath = "test1";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+
+            // WHEN
+            new SUT("testId", 0, 0, [additionalRelativePath]);
+
+            // THEN
+            expect(nutConfig.imagePaths.length).toBe(3);
+            expect(nutConfig.imagePaths).toContain(cwd());
+            expect(nutConfig.imagePaths).toContain(testFolder);
+            expect(nutConfig.imagePaths).toContain(join(testFolder, additionalRelativePath));
+        });
+
+        it("should not modify absolute path", () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const additionalAbsolutePath = "/test1";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+
+            // WHEN
+            new SUT("testId", 0, 0, [additionalAbsolutePath]);
+
+            // THEN
+            expect(nutConfig.imagePaths.length).toBe(3);
+            expect(nutConfig.imagePaths).toContain(cwd());
+            expect(nutConfig.imagePaths).toContain(testFolder);
+            expect(nutConfig.imagePaths).toContain(additionalAbsolutePath);
+        });
+    });
+
+    describe("steps", () => {
+        it("should properly update, stop and start", () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+            const tc = new SUT("testId", 0, 0);
+
+            const testStepName = "testStep1";
+            const warningTime = 5;
+            const criticalTime = 10;
+
+            // WHEN
+            tc.endOfStep(testStepName, warningTime, criticalTime);
+
+            // THEN
+            expect(testExecutionContext.updateCurrentTestStep).toBeCalledTimes(1);
+            expect(testExecutionContext.updateCurrentTestStep).toBeCalledWith({
+                id: testStepName,
+                criticalTime: criticalTime,
+                warningTime: warningTime
+            });
+            expect(testExecutionContext.endTestStep).toBeCalledTimes(1);
+            expect(testExecutionContext.startTestStep).toBeCalledTimes(2);
+        })
+    });
+
+    describe("saveResult", () => {
+        it("should stop and start a teststep", () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+            const tc = new SUT("testId", 0, 0);
+
+            // WHEN
+            tc.saveResult();
+
+            // THEN
+            expect(testExecutionContext.endTestStep).toBeCalledTimes(1);
+            expect(testExecutionContext.startTestStep).toBeCalledTimes(1);
+        })
+    });
+
+    describe("handleException", () => {
+        it("should take a screenshot and update the testcase update ", async () => {
+            // GIVEN
+            const testFolder = "testCaseFolder";
+            const SUT = createTestCaseClass(testExecutionContext, project, testFolder);
+            const tc = new SUT("testId", 0, 0);
+            const testError = new Error("testError");
+
+            // WHEN
+            await tc.handleException(testError);
+
+            // THEN
+            expect(testExecutionContext.updateCurrentTestCase).toBeCalledTimes(1);
+            expect(testExecutionContext.updateCurrentTestCase).toBeCalledWith({
+                error: testError
+            });
+        })
+    });
+});

--- a/packages/sakuli-legacy/src/context/common/test-case.class.ts
+++ b/packages/sakuli-legacy/src/context/common/test-case.class.ts
@@ -1,7 +1,9 @@
+import {cwd} from "process";
 import {Project, TestExecutionContext} from "@sakuli/core";
 import nutConfig from "./nut-global-config.class";
 import {ScreenApi} from "./actions/screen.function";
-import {ifPresent} from "@sakuli/commons";
+import {ifPresent, Maybe, throwIfAbsent} from "@sakuli/commons";
+import {isAbsolute, join} from "path";
 
 type TestMetaData = {
     suiteName: string,
@@ -18,7 +20,7 @@ const getTestMetaData = (ctx: TestExecutionContext): TestMetaData => {
     });
 };
 
-export function createTestCaseClass(ctx: TestExecutionContext, project: Project) {
+export function createTestCaseClass(ctx: TestExecutionContext, project: Project, currentTestFolder: Maybe<string>) {
     return class TestCase {
         constructor(
             readonly caseId?: string,
@@ -29,11 +31,22 @@ export function createTestCaseClass(ctx: TestExecutionContext, project: Project)
             ctx.logger.info(`Start Testcase ${caseId}`);
             ctx.startTestCase({id: caseId});
             ctx.startTestStep({});
-            nutConfig.addImagePath(..._imagePaths);
+            nutConfig.imagePaths = [cwd()];
+            const testFolder = throwIfAbsent(currentTestFolder, new Error("No testcase folder provided"));
+            nutConfig.addImagePath(testFolder);
+            this.addImagePaths(..._imagePaths);
         }
 
         addImagePaths(...paths: string[]) {
-            nutConfig.addImagePath(...paths);
+            for (let path of paths) {
+                if (isAbsolute(path)) {
+                    nutConfig.addImagePath(path);
+                } else {
+                    ifPresent(currentTestFolder,
+                        testFolder => nutConfig.addImagePath(join(testFolder, path))
+                    );
+                }
+            }
         }
 
         endOfStep(
@@ -53,7 +66,7 @@ export function createTestCaseClass(ctx: TestExecutionContext, project: Project)
 
         async handleException<E extends Error>(e: E) {
             ctx.logger.info(`Error: ${e.message}`);
-            const { suiteName, caseName } = getTestMetaData(ctx);
+            const {suiteName, caseName} = getTestMetaData(ctx);
             await ScreenApi.takeScreenshotWithTimestamp(`error_${suiteName}_${caseName}`);
             ctx.updateCurrentTestCase({
                 error: e,
@@ -74,6 +87,7 @@ export function createTestCaseClass(ctx: TestExecutionContext, project: Project)
         }
 
         getTestCaseFolderPath() {
+            return throwIfAbsent(currentTestFolder, new Error("No test path configured."));
         }
 
         getTestSuiteFolderPath() {
@@ -82,7 +96,7 @@ export function createTestCaseClass(ctx: TestExecutionContext, project: Project)
 
         async throwExecption(message: string, screenshot: boolean) {
             if (screenshot) {
-                const { suiteName, caseName } = getTestMetaData(ctx);
+                const {suiteName, caseName} = getTestMetaData(ctx);
                 await ScreenApi.takeScreenshotWithTimestamp(`error_${suiteName}_${caseName}`);
             }
             throw Error(message);


### PR DESCRIPTION
Fixes loading of sample images to be searched testcase folder.
Until now there's no default to load sample images from the current testcase folder.

This PR injects the current folder to the testcase in order to make this possible.