### PR TITLE
Bugfix/75/return code

### DIFF
--- a/packages/sakuli-cli/src/run-command.function.ts
+++ b/packages/sakuli-cli/src/run-command.function.ts
@@ -30,9 +30,13 @@ export const runCommand: CommandModuleProvider = (sakuli: SakuliInstance): Comma
         async handler(runOptions: any) {
             const logStream = createWriteStream('sakuli.log', {flags: 'a'});
             sakuli.testExecutionContext.logger.onEvent(e => {
-                logStream.write(`[${e.time}] ${e.level} ${e.message}\n`)
-                if (e.data) {
-                    logStream.write(`${JSON.stringify(e.data, null, 2)}\n`)
+                try {
+                    logStream.write(`[${e.time}] ${e.level} ${e.message}\n`);
+                    if (e.data) {
+                        logStream.write(`${JSON.stringify(e.data, null, 2)}\n`)
+                    }
+                } catch (e) {
+                    // ignore
                 }
             });
             const unmount = renderExecution(sakuli.testExecutionContext);

--- a/packages/sakuli-core/src/runner/sakuli-runner.class.ts
+++ b/packages/sakuli-core/src/runner/sakuli-runner.class.ts
@@ -6,6 +6,7 @@ import {JsScriptExecutor} from "./js-script-executor.class";
 import {join, resolve} from "path";
 import {TestExecutionContext} from "./test-execution-context";
 import {TestFile} from "../loader/model/test-file.interface";
+import {ifPresent} from "@sakuli/commons";
 
 export class SakuliRunner implements TestExecutionLifecycleHooks {
 
@@ -26,7 +27,18 @@ export class SakuliRunner implements TestExecutionLifecycleHooks {
     async execute(project: Project): Promise<any> {
         this.testExecutionContext.startExecution();
         process.on('unhandledRejection', error => {
-
+            console.log(error);
+            if (error instanceof Error) {
+                ifPresent(this.testExecutionContext.getCurrentTestCase(), () => {
+                    this.testExecutionContext.updateCurrentTestCase({error});
+                });
+            }
+        });
+        process.on('uncaughtException', error => {
+            console.log(error);
+            ifPresent(this.testExecutionContext.getCurrentTestCase(), () => {
+                this.testExecutionContext.updateCurrentTestCase({error});
+            });
         });
         // onProject Phase
         await this.onProject(project, this.testExecutionContext);

--- a/packages/sakuli-legacy/src/context/common/test-case.class.ts
+++ b/packages/sakuli-legacy/src/context/common/test-case.class.ts
@@ -14,12 +14,12 @@ const getTestMetaData = (ctx: TestExecutionContext): TestMetaData => {
     const suiteName = ifPresent(ctx.getCurrentTestSuite(), suite => ifPresent(suite.id, id => id, () => "UNKNOWN_TESTSUITE"), () => "UNKNOWN_TESTSUITE");
     let caseName = ifPresent(ctx.getCurrentTestCase(), testCase => testCase.id, () => null);
     caseName = ifPresent(caseName, () => caseName, () => {
-        return ifPresent(ctx.getCurrentTestSuite(), ts => `testcase_${ts.testCases.length - 1}`, () => "testcase_0");
+        return ifPresent(ctx.getCurrentTestSuite(), ts => `testcase_${ts.testCases.length}`, () => "testcase_1");
     });
 
     return ({
         suiteName,
-        caseName: caseName || "testcase_0"
+        caseName: caseName || "testcase_1"
     });
 };
 

--- a/packages/sakuli-legacy/src/context/common/test-case.class.ts
+++ b/packages/sakuli-legacy/src/context/common/test-case.class.ts
@@ -12,11 +12,14 @@ type TestMetaData = {
 
 const getTestMetaData = (ctx: TestExecutionContext): TestMetaData => {
     const suiteName = ifPresent(ctx.getCurrentTestSuite(), suite => ifPresent(suite.id, id => id, () => "UNKNOWN_TESTSUITE"), () => "UNKNOWN_TESTSUITE");
-    const caseName = ifPresent(ctx.getCurrentTestCase(), testCase => ifPresent(testCase.id, id => id, () => "UNKNOWN_TESTCASE"), () => "UNKNOWN_TESTCASE");
+    let caseName = ifPresent(ctx.getCurrentTestCase(), testCase => testCase.id, () => null);
+    caseName = ifPresent(caseName, () => caseName, () => {
+        return ifPresent(ctx.getCurrentTestSuite(), ts => `testcase_${ts.testCases.length - 1}`, () => "testcase_0");
+    });
 
     return ({
         suiteName,
-        caseName
+        caseName: caseName || "testcase_0"
     });
 };
 


### PR DESCRIPTION
This PR updates / extends exception handling to update testcases on error.
Otherwise, errors caused by e.g. invalid method calls inside a testcase are not handled properly and a testexecution always exits with return value 0, shadowing test failures.