### PR TITLE
(#127) Removed argument from shebang line

### DIFF
--- a/packages/sakuli-cli/src/index.ts
+++ b/packages/sakuli-cli/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import * as figlet from "figlet";
 


### PR DESCRIPTION
On Linux systems, arguments are not parsed properly which causes Sakuli to fail