### PR TITLE
Feature/221/1000 div problem

### DIFF
--- a/packages/integration-tests/package-lock.json
+++ b/packages/integration-tests/package-lock.json
@@ -1152,9 +1152,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.7.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-			"integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
+			"version": "12.12.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
+			"integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -1170,6 +1170,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+		},
+		"abstract-logging": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
+			"integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -1274,6 +1280,12 @@
 					}
 				}
 			}
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -1397,6 +1409,34 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"avvio": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/avvio/-/avvio-6.2.2.tgz",
+			"integrity": "sha512-7+yznbJOMoHQ8Z8VH+1meyRjtxUW8za6gqnHBl8DqlX5qPtaclNIgWrKrTLuIbfn2+1/EGkcr+rQXI8DYVU4RA==",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"debug": "^4.0.0",
+				"fastq": "^1.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -1869,9 +1909,9 @@
 			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
 		},
 		"chromedriver": {
-			"version": "76.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.0.tgz",
-			"integrity": "sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==",
+			"version": "78.0.1",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
+			"integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
 			"requires": {
 				"del": "^4.1.1",
 				"extract-zip": "^1.6.7",
@@ -2558,6 +2598,12 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
+		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -3117,6 +3163,12 @@
 				}
 			}
 		},
+		"fast-decode-uri-component": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+			"dev": true
+		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -3140,15 +3192,81 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
+		"fast-json-stringify": {
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.15.6.tgz",
+			"integrity": "sha512-UKypbA85Qc53b8xdcXWI3g7TBnOV34+cYJczHJZv4KQ4mF3H9Mk3547FjX3lvUJO4Wf5kK0IhSO0eUTJKKcmEw==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.2",
+				"deepmerge": "^4.0.0"
+			}
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
+		"fast-redact": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==",
+			"dev": true
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+			"dev": true
+		},
+		"fastify": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-2.10.0.tgz",
+			"integrity": "sha512-ieWwtPZPpcurQlRBmWer6rSq/2WAKAI3yPkh2oBbQ98U5BnWjhcLXYYgBRTS1TDu2evwbXwnRVdLpILVC2O5XA==",
+			"dev": true,
+			"requires": {
+				"abstract-logging": "^1.0.0",
+				"ajv": "^6.10.2",
+				"avvio": "^6.2.2",
+				"fast-json-stringify": "^1.15.5",
+				"find-my-way": "^2.0.0",
+				"flatstr": "^1.0.12",
+				"light-my-request": "^3.4.1",
+				"middie": "^4.0.1",
+				"pino": "^5.13.2",
+				"proxy-addr": "^2.0.4",
+				"readable-stream": "^3.1.1",
+				"rfdc": "^1.1.2",
+				"secure-json-parse": "^1.0.0",
+				"tiny-lru": "^7.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
 			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+		},
+		"fastq": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.0"
+			}
 		},
 		"fd-slicer": {
 			"version": "1.0.1",
@@ -3198,6 +3316,17 @@
 				"unpipe": "~1.0.0"
 			}
 		},
+		"find-my-way": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.1.tgz",
+			"integrity": "sha512-pzZA9/PlhDGG5PRzmd4vH4AbKW7FO68RE7q2I3NzjJHcVPukYbDA7bPdArg7ySKfS6pKki+qhrawFoN6aNZfjA==",
+			"dev": true,
+			"requires": {
+				"fast-decode-uri-component": "^1.0.0",
+				"safe-regex2": "^2.0.0",
+				"semver-store": "^0.3.0"
+			}
+		},
 		"find-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3205,6 +3334,12 @@
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
+		},
+		"flatstr": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -4728,6 +4863,29 @@
 				"immediate": "~3.0.5"
 			}
 		},
+		"light-my-request": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.6.2.tgz",
+			"integrity": "sha512-xg51G/FOoajQqmVbrH8WmocL3gjznIf79rMcCiaxT+lypwaXTvWyCZY2YkOwesqkS3mDlApgnHzVcqvIsc7YOQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.2",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -4906,6 +5064,24 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
+			}
+		},
+		"middie": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/middie/-/middie-4.0.1.tgz",
+			"integrity": "sha512-eYK6EEHZiYpQMYPmeCb/vC9ZzJg1HCqi1ot/fQs1sPZKt/XREgXouQ7g6c9J5XvDV5203JjbpovCYNkHcHgTpQ==",
+			"dev": true,
+			"requires": {
+				"path-to-regexp": "^3.0.0",
+				"reusify": "^1.0.2"
+			},
+			"dependencies": {
+				"path-to-regexp": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.1.0.tgz",
+					"integrity": "sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==",
+					"dev": true
+				}
 			}
 		},
 		"miller-rabin": {
@@ -5593,6 +5769,26 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"pino": {
+			"version": "5.13.5",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-5.13.5.tgz",
+			"integrity": "sha512-NSArDZnjIXgzTLsYA5EhYwLiMe2OmGJ73760Wt5Vj44kUcuPJk4ub29BKtWXGAMwVmW1cQ7Q8jQaLjY/5Gxqcw==",
+			"dev": true,
+			"requires": {
+				"fast-redact": "^2.0.0",
+				"fast-safe-stringify": "^2.0.7",
+				"flatstr": "^1.0.9",
+				"pino-std-serializers": "^2.3.0",
+				"quick-format-unescaped": "^3.0.3",
+				"sonic-boom": "^0.7.5"
+			}
+		},
+		"pino-std-serializers": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+			"dev": true
+		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -6178,6 +6374,12 @@
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
+		"quick-format-unescaped": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+			"dev": true
+		},
 		"quote-stream": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -6453,6 +6655,18 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
+		"rfdc": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+			"integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+			"dev": true
+		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -6501,6 +6715,23 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"safe-regex2": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+			"integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+			"dev": true,
+			"requires": {
+				"ret": "~0.2.0"
+			},
+			"dependencies": {
+				"ret": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+					"integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+					"dev": true
+				}
+			}
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6527,6 +6758,12 @@
 				"xmlchars": "^2.1.1"
 			}
 		},
+		"secure-json-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-1.0.0.tgz",
+			"integrity": "sha512-kMg4jXttRQzVyLebIDc+MRxCueJ/zsmHpCn59BRd0mZUCd+V02wNd7/Pds8Nyhv7jfLHo1KkUOzdIF7cRMU4LQ==",
+			"dev": true
+		},
 		"selenium-webdriver": {
 			"version": "4.0.0-alpha.4",
 			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.4.tgz",
@@ -6542,6 +6779,12 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"semver-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
+			"integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -6783,6 +7026,15 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
+			}
+		},
+		"sonic-boom": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+			"integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+			"dev": true,
+			"requires": {
+				"flatstr": "^1.0.12"
 			}
 		},
 		"source-map": {
@@ -7133,6 +7385,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz",
 			"integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c="
+		},
+		"tiny-lru": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.2.tgz",
+			"integrity": "sha512-cmc9OOwmnAJtyFBYaznKR3abypEhWecarFrvS5db6qwSgoaDUWV0JX+mdh6B9wN60Wux3+gE1vjzxkoqxFBjqw==",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.30",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -17,13 +17,16 @@
   "scripts": {
     "demo-page": "node index",
     "test": "NODE_NO_WARNINGS=1 sakuli run legacy-suite",
-    "test:debug": "node --inspect node_modules/@sakuli/cli/dist/index run legacy-suite"
+    "test:debug": "node --inspect node_modules/@sakuli/cli/dist/index run legacy-suite",
+    "preperformance-test": "node performance/server & echo $! > .pid",
+    "performance-test": "sakuli run performance/checks",
+    "postperformance-test": "kill -9 $(cat .pid) && rm .pid"
   },
   "dependencies": {
-    "@sakuli/legacy-types": "^2.1.3",
     "@sakuli/cli": "^2.1.3",
     "@sakuli/legacy": "^2.1.3",
-    "chromedriver": "^76.0.0",
+    "@sakuli/legacy-types": "^2.1.3",
+    "chromedriver": "^78.0.0",
     "concurrently": "^4.1.0",
     "execa": "^1.0.0",
     "express": "^4.16.4",
@@ -38,5 +41,8 @@
     "presetProvider": [
       "@sakuli/legacy"
     ]
+  },
+  "devDependencies": {
+    "fastify": "^2.10.0"
   }
 }

--- a/packages/integration-tests/performance/checks/case1/100.ts
+++ b/packages/integration-tests/performance/checks/case1/100.ts
@@ -1,0 +1,4 @@
+import testSuite from "../test-suite";
+
+
+testSuite(100);

--- a/packages/integration-tests/performance/checks/case1/1000.ts
+++ b/packages/integration-tests/performance/checks/case1/1000.ts
@@ -1,0 +1,4 @@
+import testSuite from "../test-suite";
+
+
+testSuite(1000);

--- a/packages/integration-tests/performance/checks/case1/10000.ts
+++ b/packages/integration-tests/performance/checks/case1/10000.ts
@@ -1,0 +1,4 @@
+import testSuite from "../test-suite";
+
+
+testSuite(10000);

--- a/packages/integration-tests/performance/checks/case1/5000.ts
+++ b/packages/integration-tests/performance/checks/case1/5000.ts
@@ -1,0 +1,4 @@
+import testSuite from "../test-suite";
+
+
+testSuite(5000);

--- a/packages/integration-tests/performance/checks/test-suite.ts
+++ b/packages/integration-tests/performance/checks/test-suite.ts
@@ -1,0 +1,13 @@
+export default async function (divCount: number) {
+    const testCase = new TestCase(`Performance with ${divCount} divs`);
+    try {
+        await _navigateTo(`http://127.0.0.1:3000/${divCount}`);
+        testCase.endOfStep('page-load')
+        await _highlight(_div('div-82'));
+        testCase.endOfStep('element-located')
+    } catch (e) {
+        await testCase.handleException(e);
+    } finally {
+        await testCase.saveResult();
+    }
+}

--- a/packages/integration-tests/performance/checks/testsuite.properties
+++ b/packages/integration-tests/performance/checks/testsuite.properties
@@ -1,0 +1,2 @@
+testsuite.id=checks
+testsuite.browser=chrome

--- a/packages/integration-tests/performance/checks/testsuite.suite
+++ b/packages/integration-tests/performance/checks/testsuite.suite
@@ -1,0 +1,4 @@
+case1/100.ts https://sakuli.io
+case1/1000.ts https://sakuli.io
+case1/5000.ts https://sakuli.io
+case1/10000.ts https://sakuli.io

--- a/packages/integration-tests/performance/server.js
+++ b/packages/integration-tests/performance/server.js
@@ -1,0 +1,26 @@
+const fastify = require('fastify')();
+
+fastify.get('/:count', async (req, reply) => {
+    const count = req.params.count || 10;
+    reply.header('Content-Type', 'text/html; charset=utf-8');
+    return `
+        <html>
+            <body>
+                ${Array.from({length: count}, (_, i) => i).map(i => `
+                    <div id="div-${i}">${i}</div>
+                `).join('\n')}
+            </body>
+        </html>
+    `
+})
+
+const main = async () => {
+    try {
+        await fastify.listen(3000)
+    } catch(err) {
+        fastify.log.error(err);
+        process.exit();
+    }
+};
+
+main();

--- a/packages/sakuli-legacy/package-lock.json
+++ b/packages/sakuli-legacy/package-lock.json
@@ -1247,9 +1247,9 @@
 			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
 		},
 		"chromedriver": {
-			"version": "76.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.0.tgz",
-			"integrity": "sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==",
+			"version": "78.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.0.tgz",
+			"integrity": "sha512-DknHzDOLTOY8rX/uf7s0/wuNdUsBTnzG3VV2JYbxJ5AGGp0oZ/j3p1ITHb3PkBN2pFXk5H7zQT1sQL7WVKDP2g==",
 			"dev": true,
 			"requires": {
 				"del": "^4.1.1",

--- a/packages/sakuli-legacy/package.json
+++ b/packages/sakuli-legacy/package.json
@@ -55,7 +55,7 @@
     "@types/properties-reader": "0.0.1",
     "@types/selenium-webdriver": "4.0.0",
     "@types/yargs": "^12.0.12",
-    "chromedriver": "76.0.0",
+    "chromedriver": "78.0.0",
     "dockerode": "^2.5.8",
     "express": "^4.16.4",
     "geckodriver": "^1.16.2",

--- a/packages/sakuli-legacy/src/context/legacy-lifecycle-hooks.class.ts
+++ b/packages/sakuli-legacy/src/context/legacy-lifecycle-hooks.class.ts
@@ -40,7 +40,7 @@ export class LegacyLifecycleHooks implements TestExecutionLifecycleHooks {
         this.uiOnly = properties.isUiOnly();
         if (!this.uiOnly) {
             this.driver = createDriverFromProject(project, this.builder);
-            this.driver.manage().window().maximize();
+            await this.driver.manage().window().maximize();
         }
     }
 

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
@@ -1,4 +1,4 @@
-import {By, ThenableWebDriver} from "selenium-webdriver";
+import {By, ThenableWebDriver, WebElement} from "selenium-webdriver";
 import {createTestEnv, createTestExecutionContextMock, mockHtml, TestEnvironment} from "../__mocks__";
 import {AccessorUtil} from "./accessor-util.class";
 import {RelationsResolver} from "../relations";
@@ -8,6 +8,9 @@ import {getTestBrowserList} from "../__mocks__/get-browser-list.function";
 
 jest.setTimeout(15_000);
 describe('AccessorUtil', () => {
+
+    const {arrayContaining} = expect;
+
     describe.each(getTestBrowserList())('%s', (browser: "firefox" | "chrome", local: boolean) => {
         let env: TestEnvironment;
         let accessorUtil: AccessorUtil;
@@ -32,50 +35,59 @@ describe('AccessorUtil', () => {
 
         it('should fetch fuzzy matching identifiers from element', async () => {
             await driver.get(mockHtml(`
-         <div
-            id="element-to-test"
-            aria-describedby="aria"
-            class="so many names"
-            name="my-name-is-earl"
-          >Some Text content</div>
-        `));
+             <div
+                id="element-to-test"
+                aria-describedby="aria"
+                class="so many names"
+                name="my-name-is-earl"
+              >Some Text content</div>
+            `));
             const element = await driver.findElement(By.id('element-to-test'));
-            const identifiers = await accessorUtil.getStringIdentifiersForElement(element);
-            return expect(identifiers).toEqual([
+            const identifiers = await accessorUtil.getStringIdentifiersForElement([element]);
+            expect(identifiers.length).toBe(1);
+            const [matches] = identifiers;
+            expect(matches[0]).toEqual(expect.any(WebElement));
+            expect(matches[1]).toEqual([
                 'aria', 'my-name-is-earl', 'element-to-test', 'so many names', 'Some Text content', null, null
             ]);
         });
 
         it('should fetch img src for fuzzy matching', async () => {
             await driver.get(mockHtml(`
-         <img 
-            src="https://www.consol.de/fileadmin/images/svg/consol-logo.svg"
-            id="element-to-test"
-            aria-describedby="aria"
-            class="so many names"
-            name="my-name-is-earl"
-            />
-        `));
+             <img
+                src="https://www.consol.de/fileadmin/images/svg/consol-logo.svg"
+                id="element-to-test"
+                aria-describedby="aria"
+                class="so many names"
+                name="my-name-is-earl"
+                />
+            `));
             const element = await driver.findElement(By.id('element-to-test'));
-            const identifiers = await accessorUtil.getStringIdentifiersForElement(element);
-            return expect(identifiers).toEqual([
+            const identifiers = await accessorUtil.getStringIdentifiersForElement([element]);
+            expect(identifiers.length).toBe(1);
+            const [matches] = identifiers;
+            expect(matches[0]).toEqual(expect.any(WebElement));
+            expect(matches[1]).toEqual([
                 'aria', 'my-name-is-earl', 'element-to-test', 'so many names', '', null, 'https://www.consol.de/fileadmin/images/svg/consol-logo.svg'
             ]);
         });
 
         it('should fetch button value for fuzzy matching', async () => {
             await driver.get(mockHtml(`
-         <button
-            value="foo"
-            id="element-to-test"
-            aria-describedby="aria"
-            class="so many names"
-            name="my-name-is-earl"
-            >button text</button>
-        `));
+             <button
+                value="foo"
+                id="element-to-test"
+                aria-describedby="aria"
+                class="so many names"
+                name="my-name-is-earl"
+                >button text</button>
+            `));
             const element = await driver.findElement(By.id('element-to-test'));
-            const identifiers = await accessorUtil.getStringIdentifiersForElement(element);
-            return expect(identifiers).toEqual([
+            const identifiers = await accessorUtil.getStringIdentifiersForElement([element]);
+            expect(identifiers.length).toBe(1);
+            const [matches] = identifiers;
+            expect(matches[0]).toEqual(expect.any(WebElement));
+            expect(matches[1]).toEqual([
                 'aria', 'my-name-is-earl', 'element-to-test', 'so many names', 'button text', 'foo', null
             ]);
         });

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -1,4 +1,4 @@
-import {Locator, ThenableWebDriver, until, WebElement} from "selenium-webdriver";
+import {Locator, ThenableWebDriver, until, WebElement, By} from "selenium-webdriver";
 import {TestExecutionContext} from "@sakuli/core";
 import {types} from "util";
 import {
@@ -81,7 +81,6 @@ export class AccessorUtil {
      */
     async getStringIdentifiersForElement(elements: WebElement[]) {
         return this.webDriver.executeScript<[WebElement, string[]][]>(`
-            console.log('Test');
             function getAttributes(e) {
                 return [
                     e.getAttribute('aria-describedby'),
@@ -95,11 +94,8 @@ export class AccessorUtil {
             }
             var result = [];
             var elements = arguments[0];
-            for(var i = 0; i < elements .length; i++) {
+            for(var i = 0; i < elements.length; i++) {
                 var element = elements[i];
-                if(!element) {
-                    throw Error('undefined e ' + i + ' of ' + elements.length + ' elements');
-                }
                 result.push([element, getAttributes(element)]);
             }
             return result;

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -81,24 +81,26 @@ export class AccessorUtil {
      */
     async getStringIdentifiersForElement(elements: WebElement[]) {
         return this.webDriver.executeScript<[WebElement, string[]][]>(`
-            function getAttributes(e) {
-                return [
-                    e.getAttribute('aria-describedby'),
-                    e.getAttribute('name'),
-                    e.getAttribute('id'),
-                    e.className,
-                    e.innerText,
-                    e.value,
-                    e.src
-                ]
-            }
-            var result = [];
-            var elements = arguments[0];
-            for(var i = 0; i < elements.length; i++) {
-                var element = elements[i];
-                result.push([element, getAttributes(element)]);
-            }
-            return result;
+            return (function(element) {
+                function getAttributes(e) {
+                    return [
+                        e.getAttribute('aria-describedby'),
+                        e.getAttribute('name'),
+                        e.getAttribute('id'),
+                        e.className,
+                        e.innerText,
+                        e.value,
+                        e.src
+                    ]
+                }
+                var result = [];
+                var elements = arguments[0];
+                for(var i = 0; i < elements.length; i++) {
+                    var element = elements[i];
+                    result.push([element, getAttributes(element)]);
+                }
+                return result;
+            })(arguments[0])
         `, elements);
     }
 


### PR DESCRIPTION
This PR solves a part of the element fetching performance problems.

To understand the problem, this solution and further steps I'll explain how element fetching in Sakuli Works and which parts are critical:

All logic for element fetching is derived from the requirements of sahi-api syntax e.g.:

```typescript
await _click(_button('Delete .* users'));
```

We see a typical Sakuli construct to click on a button. To separate the element fetching (`_button`) and the action (`_click`) Sakuli uses an abstract query rather than directly working on WebElements (which are returned from selenium). In this case, `_button` creates the query and `_click` can use it to invoke a click on the query result (while it is also responsible for querying). 

## How Queries and Elementfetching works

A query consists of three parts:

- A [selenium locator](https://selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/lib/by_exports_By.html).
- A [Sahi identifier](https://sakuli.io/apidoc/sakuli-legacy/globals.html#accessoridentifier). This is usually the parameter of the element accessor (in the example it is `"Delete .* users"`)
- list of relations (I'll not consider them, for now, to keep it a bit simpler.)

When resolving such a query the following will happen in Sakuli:
- The locator is resolved with selenium. In the example, it would be something similar to this: `webdriver.fetchElements(By.css('button'))` 
- Next step depends on the type of the "SahiIdentifier". I'll cover the most common way (a String):
  - Convert the String into a RegExp
  - Sakuli fetches values from different (defined) attributes for each element
  - Find elements where the fetched attribute values match the RegExp

Especially the fetching of the attribute values was very poor in performance since it executes a script for each element using [`executeScript`](https://selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_ThenableWebDriver.html#executeScript) to obtain these values. 

With this PR the iteration has moved. Now all Elements which are fetched with the locator are now passed to the script and that script fetches the attributes for ALL these elements and returns the values. By that the number of requests to the webdriver (one request per element) is reduced to a single request which dramatically reduces the roundtrips and communication overhead (especially for a lot of elements).

Unfortunately, these requests can become very large and cause a lot of communication overhead. I observed the following figures in an experiment: 
-  **SETUP** 
  - A page with 10k divs (each with an id "div-<INDEX>"
  - Query: `_div('div-84')`

The Post request/response to the Webdriver to gather the attributes took ~12s  and transferred ~2.4mb of data (1.2 for reqeust, 1.2 for response). 