### PR TITLE
Feature/254/enable typescript with sakuli version

### DIFF
--- a/packages/sakuli-rollup-hooks/package-lock.json
+++ b/packages/sakuli-rollup-hooks/package-lock.json
@@ -385,6 +385,12 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
+		"@schemastore/package": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@schemastore/package/-/package-0.0.5.tgz",
+			"integrity": "sha512-0XEiMT/Rh8I0SEIO81fo5MN3AHhONFv9SJ1IIJ5OTI3PN/jG032OPlHUMxvrun7yc6YUGtufVg2WPQVK8PaH5Q==",
+			"dev": true
+		},
 		"@types/babel__core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",

--- a/packages/sakuli-rollup-hooks/package.json
+++ b/packages/sakuli-rollup-hooks/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/sakuli/sakuli/issues"
   },
   "devDependencies": {
+    "@schemastore/package": "^0.0.5",
     "@types/common-tags": "1.8.0",
     "@types/jest": "24.0.13",
     "@types/mock-fs": "3.6.30",

--- a/packages/sakuli-rollup-hooks/src/ts-support/enable-typescript-command.class.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/enable-typescript-command.class.ts
@@ -1,18 +1,20 @@
-import {CommandModuleProvider, CommandModule, Argv} from "@sakuli/core";
+import { CommandModuleProvider, CommandModule, Argv } from "@sakuli/core";
 import execa from 'execa';
 import { createInterface } from "readline";
-import {stripIndents} from 'common-tags'
+import { stripIndents } from 'common-tags'
 import { resolve, isAbsolute, join } from "path";
-import {promises as fs} from 'fs';
+import { promises as fs } from 'fs';
 import chalk from 'chalk'
 import ora, { Ora } from 'ora';
 import { defaultTsConfig } from "./default-ts-config.const";
 import { getInstalledPresets } from "./get-installed-presets.function";
 import packageTypingMapping from "./package-typing-mapping.const";
 import { EOL } from "os";
+import { readJson } from "../read-json.function";
+import { getSakuliVersion } from "./get-sakuli-version.function";
 
 const userInput = async (question: string): Promise<string> => {
-    const rl = createInterface(process.stdin,process.stdout);
+    const rl = createInterface(process.stdin, process.stdout);
     return new Promise<string>((res, rej) => {
         rl.question(question, answer => {
             res(answer);
@@ -30,10 +32,11 @@ export const enableTypescriptCommand: CommandModuleProvider = (): CommandModule 
                 describe: 'Path to the project, can be absolute or relative to $PWD'
             }).demandOption('project') as any;
         },
-        async handler(opts: Record<string, unknown> & {$0: string, _: string[]}) {
+        async handler(opts: Record<string, unknown> & { $0: string, _: string[] }) {
             const project = `${opts['project']}`;
             const baseDir = isAbsolute(project) ? project : resolve(process.cwd(), project);
             const presets = await getInstalledPresets(baseDir);
+            const sakuliVersion = await getSakuliVersion(baseDir);
             const typingPackages = presets
                 .filter(preset => packageTypingMapping.has(preset))
                 .map(preset => packageTypingMapping.get(preset)!)
@@ -45,34 +48,34 @@ export const enableTypescriptCommand: CommandModuleProvider = (): CommandModule 
                 Would you like to proceed [${chalk.green('Y')}/${chalk.red('n')}]: ${chalk.gray('default: Y')}
 
             `);
-            if(answer.toUpperCase() !== 'n') {
-                const installs: [string, Ora][] = typingPackages.map(pkg => [pkg, ora(`Running npm i install ${pkg}`)]);
+            if (answer.toUpperCase() !== 'n') {
+                const installs: [string, Ora][] = typingPackages.map(pkg => [pkg, ora(`Running npm i install ${pkg}@${sakuliVersion}`)]);
                 const createFile = ora('Creating tsconfig.json')
-                for(let [pkg, install] of installs) {
+                for (let [pkg, install] of installs) {
                     try {
                         install.start();
-                        await execa('npm', ['i', pkg]);
+                        await execa('npm', ['i', `${pkg}@${sakuliVersion}`], {cwd: baseDir});
                         install.succeed()
-                    } catch(e) {
-                        install.fail(e);
+                    } catch (e) {
+                        install.fail(e.message);
                     }
                 }
                 try {
                     createFile.start();
-                    const cfg = {...defaultTsConfig};
+                    const cfg = { ...defaultTsConfig };
                     (cfg.compilerOptions.types as string[]).push(...typingPackages);
                     await fs.writeFile(
                         join(baseDir, 'tsconfig.json'),
                         JSON.stringify(cfg, null, 2),
-                        {flag: 'w'}
-                        );
+                        { flag: 'w' }
+                    );
                     createFile.succeed();
-                } catch(e) {
-
-                    createFile.fail();
+                } catch (e) {
+                    createFile.fail(e.message);
                     console.error(chalk.red(e));
                     process.exit(1);
                 }
+                process.exit(0);
             } else {
                 process.exit(-1);
             }

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.spec.ts
@@ -36,13 +36,13 @@ describe('getInstalledPresets', () => {
         const presets = await getInstalledPresets('/invalid');
         expect(readJson).toHaveBeenCalledWith('/invalid/package.json');
         expect(presets.length).toBe(1);
-        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']))
+        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']));
     });
 
     it('should return fallback array when json doesn\'t have sakuli property', async () => {
         const presets = await getInstalledPresets('/missing-sakuli-key');
         expect(readJson).toHaveBeenCalledWith('/missing-sakuli-key/package.json');
         expect(presets.length).toBe(1);
-        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']))
+        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']));
     });
 });

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.spec.ts
@@ -30,17 +30,19 @@ describe('getInstalledPresets', () => {
         expect(readJson).toHaveBeenCalledWith('/valid/package.json');
         expect(presets.length).toBe(1);
         expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']));
-    })
+    });
 
-    it('should return empty array when readJson throws', async () => {
+    it('should return fallback array when readJson throws', async () => {
         const presets = await getInstalledPresets('/invalid');
         expect(readJson).toHaveBeenCalledWith('/invalid/package.json');
-        expect(presets.length).toBe(0);
-    })
+        expect(presets.length).toBe(1);
+        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']))
+    });
 
-    it('should return empty array when json doesn\'t have sakuli property', async () => {
+    it('should return fallback array when json doesn\'t have sakuli property', async () => {
         const presets = await getInstalledPresets('/missing-sakuli-key');
         expect(readJson).toHaveBeenCalledWith('/missing-sakuli-key/package.json');
-        expect(presets.length).toBe(0);
-    })
+        expect(presets.length).toBe(1);
+        expect(presets).toEqual(expect.arrayContaining(['@sakuli/legacy']))
+    });
 });

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-installed-presets.function.ts
@@ -1,8 +1,9 @@
-import { PathLike } from "fs"
 import { readJson } from "../read-json.function"
 import { join } from "path";
+import { JSONSchemaForNPMPackageJsonFiles } from "@schemastore/package";
 
 export const getInstalledPresets = async (packageJsonPath: string): Promise<string[]> => {
+    const fallbackPackages = ['@sakuli/legacy'];
     try {
         const packageJson = await readJson(join(packageJsonPath, 'package.json'));
         if("sakuli" in packageJson) {
@@ -11,8 +12,8 @@ export const getInstalledPresets = async (packageJsonPath: string): Promise<stri
                 return sakuliConfig.presetProvider;
             }
         }
-        return [];
+        return fallbackPackages;
     } catch(e) {
-        return [];
+        return fallbackPackages;
     }
 }

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
@@ -10,6 +10,15 @@ jest.mock('../read-json.function.ts', () => ({
 jest.mock('execa', () => jest.fn());
 
 describe('getSakuliVersion', () => {
+
+    beforeEach(() => {
+        jest.spyOn(console, 'debug');
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    })
+
     it('should use version from dependencies in package.json', async () => {
         (<jest.Mock>readJson).mockResolvedValueOnce({
             dependencies: { '@sakuli/cli': '2.2.0-file' },
@@ -18,6 +27,7 @@ describe('getSakuliVersion', () => {
         const version = await getSakuliVersion('some/path');
         expect(version).toBe('2.2.0-file');
         expect(readJson).toHaveBeenCalledWith(join('some/path', 'package.json'));
+        expect(console.debug).not.toHaveBeenCalled();
     })
 
     it('should use version from devDependencies in package.json when not in dependencies', async () => {
@@ -35,6 +45,7 @@ describe('getSakuliVersion', () => {
         const version = await getSakuliVersion('some/path');
         expect(version).toBe('2.2.0-cli');
         expect(execa).toHaveBeenCalledWith('npx', ['sakuli', '--version'], expect.objectContaining({ cwd: 'some/path' }));
+        expect(console.debug).toHaveBeenCalledTimes(1);
     });
 
     it('should fallback to output of npx command when sakuli is not in the dependencies', async () => {
@@ -46,6 +57,7 @@ describe('getSakuliVersion', () => {
         const version = await getSakuliVersion('some/path');
         expect(version).toBe('2.2.0-cli');
         expect(execa).toHaveBeenCalledWith('npx', ['sakuli', '--version'], expect.objectContaining({ cwd: 'some/path' }));
+        expect(console.debug).toHaveBeenCalledTimes(1);
     });
 
     it('should fallback to @latest when all other mechanisms not working', async () => {
@@ -53,5 +65,6 @@ describe('getSakuliVersion', () => {
         (<jest.Mock>execa).mockRejectedValue(null);
         const version = await getSakuliVersion('some/path');
         expect(version).toBe('latest');
+        expect(console.debug).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
@@ -5,7 +5,7 @@ const execa: jest.Mock = require("execa");
 
 jest.mock('../read-json.function.ts', () => ({
     readJson: jest.fn()
-}))
+}));
 
 jest.mock('execa', () => jest.fn());
 
@@ -17,7 +17,7 @@ describe('getSakuliVersion', () => {
 
     afterEach(() => {
         jest.resetAllMocks();
-    })
+    });
 
     it('should use version from dependencies in package.json', async () => {
         (<jest.Mock>readJson).mockResolvedValueOnce({
@@ -28,7 +28,7 @@ describe('getSakuliVersion', () => {
         expect(version).toBe('2.2.0-file');
         expect(readJson).toHaveBeenCalledWith(join('some/path', 'package.json'));
         expect(console.debug).not.toHaveBeenCalled();
-    })
+    });
 
     it('should use version from devDependencies in package.json when not in dependencies', async () => {
         (<jest.Mock>readJson).mockResolvedValueOnce({

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.spec.ts
@@ -1,0 +1,57 @@
+import { getSakuliVersion } from "./get-sakuli-version.function"
+import { readJson } from "../read-json.function"
+import { join } from "path"
+const execa: jest.Mock = require("execa");
+
+jest.mock('../read-json.function.ts', () => ({
+    readJson: jest.fn()
+}))
+
+jest.mock('execa', () => jest.fn());
+
+describe('getSakuliVersion', () => {
+    it('should use version from dependencies in package.json', async () => {
+        (<jest.Mock>readJson).mockResolvedValueOnce({
+            dependencies: { '@sakuli/cli': '2.2.0-file' },
+            devDependencies: { '@sakuli/cli': '2.2.0-dev' }
+        });
+        const version = await getSakuliVersion('some/path');
+        expect(version).toBe('2.2.0-file');
+        expect(readJson).toHaveBeenCalledWith(join('some/path', 'package.json'));
+    })
+
+    it('should use version from devDependencies in package.json when not in dependencies', async () => {
+        (<jest.Mock>readJson).mockResolvedValueOnce({
+            devDependencies: { '@sakuli/cli': '2.2.0-dev' }
+        });
+        const version = await getSakuliVersion('some/path');
+        expect(version).toBe('2.2.0-dev');
+        expect(readJson).toHaveBeenCalledWith(join('some/path', 'package.json'));
+    });
+
+    it('should fallback to output of npx command when package.json cannot be read', async () => {
+        (<jest.Mock>readJson).mockRejectedValue(null);
+        (<jest.Mock>execa).mockResolvedValue({ stdout: '2.2.0-cli' });
+        const version = await getSakuliVersion('some/path');
+        expect(version).toBe('2.2.0-cli');
+        expect(execa).toHaveBeenCalledWith('npx', ['sakuli', '--version'], expect.objectContaining({ cwd: 'some/path' }));
+    });
+
+    it('should fallback to output of npx command when sakuli is not in the dependencies', async () => {
+        (<jest.Mock>readJson).mockRejectedValue({
+            dependencies: {},
+            devDependencies: {},
+        });
+        (<jest.Mock>execa).mockResolvedValue({ stdout: '2.2.0-cli' });
+        const version = await getSakuliVersion('some/path');
+        expect(version).toBe('2.2.0-cli');
+        expect(execa).toHaveBeenCalledWith('npx', ['sakuli', '--version'], expect.objectContaining({ cwd: 'some/path' }));
+    });
+
+    it('should fallback to @latest when all other mechanisms not working', async () => {
+        (<jest.Mock>readJson).mockRejectedValue(null);
+        (<jest.Mock>execa).mockRejectedValue(null);
+        const version = await getSakuliVersion('some/path');
+        expect(version).toBe('latest');
+    });
+});

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
@@ -18,11 +18,11 @@ export const getSakuliVersion = async (packageJsonPath: string) => {
     } // want to avoid nested try/catch ;)
 
     try {
-        const commandResult = await execa('npx', ['sakuli', '--version'], { cwd: packageJsonPath })
+        const commandResult = await execa('npx', ['sakuli', '--version'], { cwd: packageJsonPath });
         return commandResult.stdout;
     } catch (e) {
         console.debug(`enable-typescript could not determine version from running 'npx sakuli --version'`)
     }
 
     return 'latest';
-}
+};

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { readJson } from "../read-json.function";
 import { JSONSchemaForNPMPackageJsonFiles, Dependency } from "@schemastore/package";
 import execa = require("execa");
-import { ifPresent, throwIfAbsent } from "@sakuli/commons";
+import { ifPresent, throwIfAbsent, SimpleLogger } from "@sakuli/commons";
 
 export const getSakuliVersion = async (packageJsonPath: string) => {
     try {
@@ -13,12 +13,16 @@ export const getSakuliVersion = async (packageJsonPath: string) => {
                 const devDep = throwIfAbsent(packageJson.devDependencies);
                 return getDep(devDep);
             });
-    } catch (e) { } // want to avoid nested try/catch ;)
+    } catch (e) {
+        console.debug(`enable-typescript could not determine version from ${join(packageJsonPath, 'package.json')}`)
+    } // want to avoid nested try/catch ;)
 
     try {
         const commandResult = await execa('npx', ['sakuli', '--version'], { cwd: packageJsonPath })
         return commandResult.stdout;
-    } catch (e) { }
+    } catch (e) {
+        console.debug(`enable-typescript could not determine version from running 'npx sakuli --version'`)
+    }
 
     return 'latest';
 }

--- a/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
+++ b/packages/sakuli-rollup-hooks/src/ts-support/get-sakuli-version.function.ts
@@ -1,0 +1,24 @@
+import { join } from "path";
+import { readJson } from "../read-json.function";
+import { JSONSchemaForNPMPackageJsonFiles, Dependency } from "@schemastore/package";
+import execa = require("execa");
+import { ifPresent, throwIfAbsent } from "@sakuli/commons";
+
+export const getSakuliVersion = async (packageJsonPath: string) => {
+    try {
+        const packageJson: JSONSchemaForNPMPackageJsonFiles = await readJson(join(packageJsonPath, 'package.json'));
+        const getDep = (deps: Dependency) => throwIfAbsent(deps['@sakuli/cli']);
+        return ifPresent(packageJson.dependencies, getDep,
+            () => {
+                const devDep = throwIfAbsent(packageJson.devDependencies);
+                return getDep(devDep);
+            });
+    } catch (e) { } // want to avoid nested try/catch ;)
+
+    try {
+        const commandResult = await execa('npx', ['sakuli', '--version'], { cwd: packageJsonPath })
+        return commandResult.stdout;
+    } catch (e) { }
+
+    return 'latest';
+}


### PR DESCRIPTION
Best way to test:
- Rebuild Sakuli `npm run rebuild`
- create a sakuli dummy project at `/some/where/on/your/system`
- navigate to `cd packages/integration-tests`
- run `npx sakuli enable-typescript /some/where/on/your/system`

Verify created files and versions according to the ACC Crit.