### PR TITLE
Feature/341/error logging

### DIFF
--- a/packages/sakuli-rollup-hooks/__mock__/error.js
+++ b/packages/sakuli-rollup-hooks/__mock__/error.js
@@ -1,0 +1,1 @@
+console.log("this should throw an error"));

--- a/packages/sakuli-rollup-hooks/src/rollup-lifecycle-hooks.class.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/rollup-lifecycle-hooks.class.spec.ts
@@ -1,5 +1,5 @@
 import {RollupLifecycleHooks} from "./rollup-lifecycle-hooks.class";
-import {join, resolve} from "path";
+import {join} from "path";
 import {Project} from "@sakuli/core";
 import {mockPartial} from "sneer";
 
@@ -33,10 +33,6 @@ describe('RollupLifecycleHooks', () => {
         // GIVEN
         const hooks = new RollupLifecycleHooks();
         const fileName = "error.js";
-        const filePath = resolve("__mock__", fileName);
-        const expectedError = new Error(`Syntax error in file ${filePath} on line 1, column 41.
-1: console.log(\"this should throw an error\"));
-                                            ^`);
 
         // WHEN
         const o = hooks.readFileContent({
@@ -44,7 +40,7 @@ describe('RollupLifecycleHooks', () => {
         }, project);
 
         // THEN
-        await expect(o).rejects.toThrowError(expectedError);
+        await expect(o).rejects.toThrowError(/^Syntax error in file .* on line 1, column 41\.\n1: console.log\("this should throw an error"\)\);\n.*$/);
     });
 
     it('should add typescript plugin if file extension is .ts', async () => {

--- a/packages/sakuli-rollup-hooks/src/rollup-lifecycle-hooks.class.spec.ts
+++ b/packages/sakuli-rollup-hooks/src/rollup-lifecycle-hooks.class.spec.ts
@@ -1,6 +1,6 @@
 import {RollupLifecycleHooks} from "./rollup-lifecycle-hooks.class";
 import {join, resolve} from "path";
-import {Project, TestExecutionContext} from "@sakuli/core";
+import {Project} from "@sakuli/core";
 import {mockPartial} from "sneer";
 
 describe('RollupLifecycleHooks', () => {
@@ -29,6 +29,24 @@ describe('RollupLifecycleHooks', () => {
         expect(o).toContain("console.log(pi)");
         return expect(o.trim().endsWith("}())"));
     });
+    it('should throw on parser errors', async () => {
+        // GIVEN
+        const hooks = new RollupLifecycleHooks();
+        const fileName = "error.js";
+        const filePath = resolve("__mock__", fileName);
+        const expectedError = new Error(`Syntax error in file ${filePath} on line 1, column 41.
+1: console.log(\"this should throw an error\"));
+                                            ^`);
+
+        // WHEN
+        const o = hooks.readFileContent({
+            path: fileName,
+        }, project);
+
+        // THEN
+        await expect(o).rejects.toThrowError(expectedError);
+    });
+
     it('should add typescript plugin if file extension is .ts', async () => {
         const hooks = new RollupLifecycleHooks();
 
@@ -47,7 +65,5 @@ describe('RollupLifecycleHooks', () => {
         await expect(hooks.readFileContent({
             path: 'ts/error.ts'
         }, project)).rejects.toEqual(expect.anything());
-
     });
-
 });


### PR DESCRIPTION
This PR introduces enhanced error logging for JS files.

In case of syntactical errors like superfluous braces rollup will throw an error.
This error object also contains info about where the error occurs (file, line, column) as well as a short snippet which highlights it.

Unfortunately it is not quite possible to provide the exact same output for TypeScript files. The TypeScript plugin handles these errors itself and only provides an error message which contains a message + line and column in (l:c) format. However, it still gives you a concrete hint about what went wrong.