### PR TITLE
Bugfix/353/error propagation

### DIFF
--- a/packages/sakuli-legacy/src/context/sahi/action/action-api.function.ts
+++ b/packages/sakuli-legacy/src/context/sahi/action/action-api.function.ts
@@ -20,7 +20,7 @@ export function actionApi(
 
     const withRetries = createWithRetries(ctx);
     const withActionContext = createWithActionContext(ctx);
-    const withTryAcrossFrames = createWithTryAcrossFrames(webDriver);
+    const withTryAcrossFrames = createWithTryAcrossFrames(webDriver, ctx);
     const runAsAction = <ARGS extends any[], R>(name: string, fn: (...args:ARGS) => Promise<R>): ((...args: ARGS) => Promise<R>) => {
         return withActionContext(name, withTryAcrossFrames(withRetries(5, fn)));
     };

--- a/packages/sakuli-legacy/src/context/sahi/action/utils/create-with-retries.function.ts
+++ b/packages/sakuli-legacy/src/context/sahi/action/utils/create-with-retries.function.ts
@@ -16,9 +16,10 @@ export function createWithRetries(
                 } catch (e) {
                     if (e instanceof SeleniumErrors.StaleElementReferenceError) {
                         --retries;
-                        ctx.logger.debug(`StaleElement: ${initialTries - retries} - ${e.stack}`)
+                        ctx.logger.trace(`StaleElement: ${initialTries - retries} - ${e.stack}`)
                     } else {
-                        throw Error(`A non StaleElementReferenceError is thrown during retrying;  \n${e}`)
+                        ctx.logger.trace(`A non StaleElementReferenceError is thrown during retrying: ${e}`);
+                        throw e;
                     }
                 }
             }

--- a/packages/sakuli-legacy/src/context/sahi/action/utils/create-with-try-across-frames.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/action/utils/create-with-try-across-frames.function.spec.ts
@@ -1,6 +1,8 @@
-import { createWithTryAcrossFrames } from "./create-with-try-across-frames.function"
-import { ThenableWebDriver, TargetLocator } from "selenium-webdriver"
-import { mockPartial } from "sneer";
+import {createWithTryAcrossFrames} from "./create-with-try-across-frames.function"
+import {error as SeleniumErrors, TargetLocator, ThenableWebDriver} from "selenium-webdriver"
+import {mockPartial} from "sneer";
+import {TestExecutionContext} from "@sakuli/core";
+import {createTestExecutionContextMock} from "../../../__mocks__";
 
 describe('createTryAcrossFrames', () => {
 
@@ -15,36 +17,38 @@ describe('createTryAcrossFrames', () => {
         Symbol('frame1'),
         Symbol('frame2'),
         Symbol('frame3'),
-    ]
+    ];
+    let contextMock: TestExecutionContext;
     let withTryAcrossFrames: <ARGS extends any[], R>(fn: (...args: ARGS) => Promise<R>) => ((...args: ARGS) => Promise<R>);
 
     beforeEach(async () => {
         action = jest.fn().mockResolvedValue(actionResult);
         frameLocatorMock = jest.fn().mockResolvedValue(void 0);
         defaultContentLocatorMock = jest.fn().mockResolvedValue(void 0);
-        findElementsMock= jest.fn().mockResolvedValue([]);
+        findElementsMock = jest.fn().mockResolvedValue([]);
         targetLocatorMock = mockPartial<TargetLocator>({
             frame: frameLocatorMock,
             defaultContent: defaultContentLocatorMock
         });
+        contextMock = createTestExecutionContextMock();
 
         driverMock = mockPartial<ThenableWebDriver>({
             findElements: findElementsMock,
             switchTo: jest.fn().mockReturnValue(targetLocatorMock)
         });
 
-        withTryAcrossFrames = createWithTryAcrossFrames(driverMock);
-    })
+        withTryAcrossFrames = createWithTryAcrossFrames(driverMock, contextMock);
+    });
 
     it('should not invoke frame switches on instant success', async () => {
         findElementsMock.mockResolvedValueOnce(pseudoFrames);
         const actionAcrossFrames = withTryAcrossFrames(action);
-        await expect(actionAcrossFrames(1,2,3)).resolves.toBe(actionResult);
+        await expect(actionAcrossFrames(1, 2, 3)).resolves.toBe(actionResult);
         expect(frameLocatorMock).toHaveBeenCalledTimes(0);
         expect(defaultContentLocatorMock).toHaveBeenCalledTimes(0);
         expect(action).toHaveBeenCalledTimes(1);
 
-    })
+    });
 
     it('should try an action in each frame until success', async () => {
         action.mockRejectedValueOnce("Error in default");
@@ -52,14 +56,13 @@ describe('createTryAcrossFrames', () => {
         findElementsMock.mockResolvedValueOnce(pseudoFrames);
         const actionAcrossFrames = withTryAcrossFrames(action);
 
-        await expect(actionAcrossFrames(1,2,3)).resolves.toBe(actionResult);
+        await expect(actionAcrossFrames(1, 2, 3)).resolves.toBe(actionResult);
         expect(frameLocatorMock).toHaveBeenCalledTimes(2);
         expect(frameLocatorMock).toHaveBeenNthCalledWith(1, pseudoFrames[0]);
         expect(frameLocatorMock).toHaveBeenNthCalledWith(2, pseudoFrames[1]);
         expect(defaultContentLocatorMock).toHaveBeenCalledTimes(2);
         expect(action).toHaveBeenCalledTimes(3);
-
-    })
+    });
 
     it('should rethrow latest error when failing in every frame', async () => {
         action.mockRejectedValueOnce("Error in default");
@@ -69,7 +72,7 @@ describe('createTryAcrossFrames', () => {
         findElementsMock.mockResolvedValueOnce(pseudoFrames);
 
         const actionAcrossFrames = withTryAcrossFrames(action);
-        await expect(actionAcrossFrames(1,2,3)).rejects.toEqual("Error in frame 2");
+        await expect(actionAcrossFrames(1, 2, 3)).rejects.toEqual("Error in frame 2");
 
         expect(frameLocatorMock).toHaveBeenCalledTimes(3);
         expect(frameLocatorMock).toHaveBeenNthCalledWith(1, pseudoFrames[0]);
@@ -77,8 +80,41 @@ describe('createTryAcrossFrames', () => {
         expect(frameLocatorMock).toHaveBeenNthCalledWith(3, pseudoFrames[2]);
         expect(defaultContentLocatorMock).toHaveBeenCalledTimes(3);
         expect(action).toHaveBeenCalledTimes(4);
+    });
 
-    })
+    it('should throw initial error if only TimeoutErrors follow', async () => {
+        action.mockRejectedValueOnce("Error in default");
+        action.mockRejectedValueOnce(new SeleniumErrors.TimeoutError("Error in frame 0"));
+        action.mockRejectedValueOnce(new SeleniumErrors.TimeoutError("Error in frame 1"));
+        action.mockRejectedValueOnce(new SeleniumErrors.TimeoutError("Error in frame 2"));
+        findElementsMock.mockResolvedValueOnce(pseudoFrames);
 
+        const actionAcrossFrames = withTryAcrossFrames(action);
+        await expect(actionAcrossFrames(1, 2, 3)).rejects.toEqual("Error in default");
 
-})
+        expect(frameLocatorMock).toHaveBeenCalledTimes(3);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(1, pseudoFrames[0]);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(2, pseudoFrames[1]);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(3, pseudoFrames[2]);
+        expect(defaultContentLocatorMock).toHaveBeenCalledTimes(3);
+        expect(action).toHaveBeenCalledTimes(4);
+    });
+
+    it('should error history if a non TimeoutError follows', async () => {
+        action.mockRejectedValueOnce("Error in default");
+        action.mockRejectedValueOnce(new SeleniumErrors.TimeoutError("Error in frame 0"));
+        action.mockRejectedValueOnce("Error in frame 1");
+        action.mockRejectedValueOnce(new SeleniumErrors.TimeoutError("Error in frame 2"));
+        findElementsMock.mockResolvedValueOnce(pseudoFrames);
+
+        const actionAcrossFrames = withTryAcrossFrames(action);
+        await expect(actionAcrossFrames(1, 2, 3)).rejects.toEqual("Error in frame 1");
+
+        expect(frameLocatorMock).toHaveBeenCalledTimes(3);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(1, pseudoFrames[0]);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(2, pseudoFrames[1]);
+        expect(frameLocatorMock).toHaveBeenNthCalledWith(3, pseudoFrames[2]);
+        expect(defaultContentLocatorMock).toHaveBeenCalledTimes(3);
+        expect(action).toHaveBeenCalledTimes(4);
+    });
+});


### PR DESCRIPTION
This PR addresses the problem of error shadowing.

This behaviour was caused by `createWithTryAcrossFrames`, which executes an action over all available frames but only stored the last error.
If a `_click` action failed due to an element not being clickable, the `tryAcrossFrames` mechanism would execute the same action in all available frames, where the element to click could not be found.
The resulting webdriver `TimeoutError` then shadowed the initial error.

To mitigate this problem we now only update the latest error in `tryAcrossFrames` on non timeout errors.