### PR TITLE
Log image location result on debug level.

### DIFF
--- a/packages/sakuli-legacy/src/context/common/region/sakuli-region.class.ts
+++ b/packages/sakuli-legacy/src/context/common/region/sakuli-region.class.ts
@@ -61,7 +61,7 @@ export function createRegionClass(ctx: TestExecutionContext, project: Project) {
               nutConfig.confidence,
               this
             );
-            ctx.logger.info(
+            ctx.logger.debug(
               `Located at: (${result.left},${result.top},${result.width},${result.height})`
             );
             resolve(


### PR DESCRIPTION
IMHO the image position is not required as a basic test execution information. After test execution, it is not possible to reconstruct the situation without a screenshot so I'd suggest to move it to debug level.