### PR TITLE
git stash canceling travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,12 @@ jobs:
         - npm ci && npm run build && lerna run typedoc
       deploy:
         - provider: script
-          skip_cleanup: false
+          skip_cleanup: true
           script: FIREFOX_WD_URL=http://localhost:4444/wd/hub CHROME_WD_URL=http://localhost:4445/wd/hub npm run lerna:publish-next
           on:
             branch: develop
         - provider: script
-          skip_cleanup: false
+          skip_cleanup: true
           script: FIREFOX_WD_URL=http://localhost:4444/wd/hub CHROME_WD_URL=http://localhost:4445/wd/hub npm run lerna:publish
           on:
             tags: true


### PR DESCRIPTION
Due to the output of git stash during cleanup, the build (deployment) is failing because of its verbose output and travis log limitations