### PR TITLE
Maintenance/548/rework ci cd

### DIFF
--- a/.build/run_linux.sh
+++ b/.build/run_linux.sh
@@ -13,7 +13,5 @@ npm test -- --runInBand --ci --bail
 npm run test:it
 npm run coverage:merge
 npm run coverage:merge-report
-if [[ $TRAVIS_NODE_VERSION = "lts/fermium" ]]; then
-  sonar-scanner
-fi
+sonar-scanner
 npm run test:e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ services:
 env:
   - LOG_MODE='ci'
 
-before_install:
+install:
   - "bash ./.build/setup_${TRAVIS_OS_NAME}.sh"
-install: true
 script:
   - "bash ./.build/run_${TRAVIS_OS_NAME}.sh"
 
@@ -41,8 +40,6 @@ stages:
   - test
   - name: deploy
     if: ((branch = develop) OR (tag IS present)) AND (type != pull_request)
-  - name: trigger-image-build
-    if: (branch = develop) AND (type != pull_request)
 
 jobs:
   include:
@@ -52,9 +49,8 @@ jobs:
       language: node_js
       node_js: lts/fermium
 
-      before_install:
+      install:
         - "bash ./.build/setup_${TRAVIS_OS_NAME}.sh"
-      install: true
       script: true
       before_deploy:
         - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
@@ -78,13 +74,5 @@ jobs:
           keep_history: true
           on:
             tags: true
-
-    - stage: trigger-image-build
-      os: linux
-      dist: bionic
-      language: node_js
-      node_js: lts/fermium
-
-      install: true
-      script:
+      after_success:
         - "bash ./.build/trigger-image-build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ dist: bionic
 language: node_js
 
 node_js:
-  - lts/dubnium
-  - lts/erbium
   - lts/fermium
 
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Feature: Add startStep to DSL [(#517)](https://github.com/sakuli/sakuli/issues/517)
   - This deprecates `testCase.endOfStep`
 - Maintenance: Update minor dependency versions [(#525)](https://github.com/sakuli/sakuli/issues/525)
+- Maintenance: Remove Node 10+12 builds [(#547)](https://github.com/sakuli/sakuli/issues/547)
 
 ## v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
   - This deprecates `testCase.endOfStep`
 - Maintenance: Update minor dependency versions [(#525)](https://github.com/sakuli/sakuli/issues/525)
 - Maintenance: Remove Node 10+12 builds [(#547)](https://github.com/sakuli/sakuli/issues/547)
+- Maintenance: Rework CI/CD pipelines [(#548)](https://github.com/sakuli/sakuli/issues/548)
 
 ## v2.4.0
 


### PR DESCRIPTION
I merged the `trigger-build-image` stage into the `deploy` stage, which will prevent the VM setup for this stage. This probably will cause an additional latest build to be triggered when a tag is pushed but I think this is negligible.

I also moved the `before-installation` step to the `installation` step because `installation: true` would just execute `true` in the VM, which is equivalent to `exit 0`.