### PR TITLE
Enhancement/397/left right of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Fux: Pull up timer fix from nut-js [(#544)](https://github.com/sakuli/sakuli/issues/544)
 - Maintenance: Remove Node 10+12 builds [(#547)](https://github.com/sakuli/sakuli/issues/547)
 - Maintenance: Rework CI/CD pipelines [(#548)](https://github.com/sakuli/sakuli/issues/548)
+- Enhancement: \_leftOf/ \_rightOf is usable outside of tables [(#397)](https://github.com/sakuli/sakuli/issues/397)
 
 ## v2.4.0
 

--- a/packages/sakuli-legacy/src/context/sahi/relations/edges.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/edges.function.spec.ts
@@ -108,4 +108,54 @@ describe("edges()", () => {
       expect(B.isAbove(A)).toBeFalsy();
     });
   });
+
+  describe("intersectsHorizontal", () => {
+    const A = edges({
+      origin: mockPartial({}),
+      location: {
+        x: 3,
+        y: 4,
+      },
+      size: {
+        width: 3,
+        height: 4,
+      },
+    });
+
+    const B = edges({
+      origin: mockPartial({}),
+      location: {
+        x: 7,
+        y: 2,
+      },
+      size: {
+        width: 3,
+        height: 4,
+      },
+    });
+
+    const D = edges({
+      origin: mockPartial({}),
+      location: {
+        x: 11,
+        y: 10,
+      },
+      size: {
+        width: 3,
+        height: 4,
+      },
+    });
+
+    it("should be D not intersects A", () => {
+      expect(D.intersectsHorizontal(A)).toBeFalsy();
+    });
+
+    it("should be B intersects A", () => {
+      expect(B.intersectsHorizontal(A)).toBeTruthy();
+    });
+
+    it("should be A intersects B", () => {
+      expect(A.intersectsHorizontal(B)).toBeTruthy();
+    });
+  });
 });

--- a/packages/sakuli-legacy/src/context/sahi/relations/edges.function.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/edges.function.ts
@@ -90,6 +90,8 @@ export interface Edge extends EdgeInfo {
   isAbove(b: EdgeInfo, anchor?: keyof EdgeInfo): boolean;
 
   intersectsVertical(b: EdgeInfo): boolean;
+
+  intersectsHorizontal(b: EdgeInfo): boolean;
 }
 
 export function edges(pos: PositionalInfo): Edge {
@@ -118,6 +120,14 @@ export function edges(pos: PositionalInfo): Edge {
     const xRange: Vector2 = [x, x + width];
     return isInVector(lx, xRange) || isInVector(rx, xRange);
   };
+  const intersectsHorizontal = ({
+    top: [tx, ty],
+    bottom: [bx, by],
+  }: EdgeInfo) => {
+    const yRange: Vector2 = [y, y + height];
+    return isInVector(ty, yRange) || isInVector(by, yRange);
+  };
+
   return {
     top,
     bottom,
@@ -131,5 +141,6 @@ export function edges(pos: PositionalInfo): Edge {
     isUnder,
     isAbove,
     intersectsVertical,
+    intersectsHorizontal,
   };
 }

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -225,7 +225,9 @@ describe("relations-api", () => {
                 <table>
                     <tr>
                         <td>left</td>
-                        <td><div id="anchor">center</div></td>
+                        <td>
+                            <div id="anchor">center</div>
+                        </td>
                         <td>right</td>
                     </tr>
                 </table>
@@ -235,19 +237,23 @@ describe("relations-api", () => {
 
         it("should find element with _leftOf", async () => {
           const anchor = await createQuery(By.css("#anchor"));
-          const leftQuery = await api._leftOf(anchor)(
-            createCssQuery(By.css("code"))
-          );
+          const leftQuery = await api._leftOf(
+            anchor,
+            0
+          )(createCssQuery(By.css("td")));
           const left = await accessorUtil.fetchElements(leftQuery);
+          expect(await left[0].getText()).toBe("left");
           expect(left.length).toBe(1);
         });
 
         it("should find element with _rightOf", async () => {
           const anchor = await createQuery(By.css("#anchor"));
-          const leftQuery = await api._rightOf(anchor)(
-            createCssQuery(By.css("code"))
-          );
-          const right = await accessorUtil.fetchElements(leftQuery);
+          const rightQuery = await api._rightOf(
+            anchor,
+            0
+          )(createCssQuery(By.css("td")));
+          const right = await accessorUtil.fetchElements(rightQuery);
+          expect(await right[0].getText()).toBe("right");
           expect(right.length).toBe(1);
         });
 
@@ -256,9 +262,11 @@ describe("relations-api", () => {
           const leftQuery = await api._leftOrRightOf(
             anchor,
             0
-          )(createCssQuery(By.css("code")));
+          )(createCssQuery(By.css("td")));
           const leftOrRight = await accessorUtil.fetchElements(leftQuery);
-          expect(leftOrRight.length).toBe(1);
+          expect(await leftOrRight[0].getText()).toBe("left");
+          expect(await leftOrRight[1].getText()).toBe("right");
+          expect(leftOrRight.length).toBe(2);
         });
       });
 

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -218,7 +218,7 @@ describe("relations-api", () => {
         });
       });
 
-      describe("horizontal", () => {
+      describe("horizontal relations", () => {
         beforeAll(async () => {
           await driver.get(
             mockHtml(`

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -230,6 +230,7 @@ describe("relations-api", () => {
                         </td>
                         <td>right</td>
                     </tr>
+                    <tr>below</tr>
                 </table>
                 `)
           );
@@ -243,7 +244,7 @@ describe("relations-api", () => {
           )(createCssQuery(By.css("td")));
           const left = await accessorUtil.fetchElements(leftQuery);
           expect(await left[0].getText()).toBe("left");
-          expect(left.length).toBe(1);
+          expect(left.length).toBe(2);
         });
 
         it("should find element with _rightOf", async () => {
@@ -251,7 +252,7 @@ describe("relations-api", () => {
           const rightQuery = await api._rightOf(
             anchor,
             0
-          )(createCssQuery(By.css("td")));
+          )(await createCssQuery(By.css("td")));
           const right = await accessorUtil.fetchElements(rightQuery);
           expect(await right[0].getText()).toBe("right");
           expect(right.length).toBe(1);
@@ -264,9 +265,10 @@ describe("relations-api", () => {
             0
           )(createCssQuery(By.css("td")));
           const leftOrRight = await accessorUtil.fetchElements(leftQuery);
+          expect(leftOrRight.length).toBe(3);
           expect(await leftOrRight[0].getText()).toBe("left");
-          expect(await leftOrRight[1].getText()).toBe("right");
-          expect(leftOrRight.length).toBe(2);
+          expect(await leftOrRight[1].getText()).toBe("center");
+          expect(await leftOrRight[2].getText()).toBe("right");
         });
       });
 

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -244,7 +244,7 @@ describe("relations-api", () => {
           )(createCssQuery(By.css("td")));
           const left = await accessorUtil.fetchElements(leftQuery);
           expect(await left[0].getText()).toBe("left");
-          expect(left.length).toBe(2);
+          expect(left.length).toBe(1);
         });
 
         it("should find element with _rightOf", async () => {
@@ -265,10 +265,9 @@ describe("relations-api", () => {
             0
           )(createCssQuery(By.css("td")));
           const leftOrRight = await accessorUtil.fetchElements(leftQuery);
-          expect(leftOrRight.length).toBe(3);
+          expect(leftOrRight.length).toBe(2);
           expect(await leftOrRight[0].getText()).toBe("left");
-          expect(await leftOrRight[1].getText()).toBe("center");
-          expect(await leftOrRight[2].getText()).toBe("right");
+          expect(await leftOrRight[1].getText()).toBe("right");
         });
       });
 

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -341,33 +341,27 @@ describe("relations-api", () => {
           keyof ParentApi | "_near" | "_in"
         >;
         it.each(<[number, PositionMethod, number, string[]][]>[
-          [
-            3,
-            "_leftOf",
-            0,
-            ["Rhona Davidson", "Integration Specialist", "Tokyo"],
-          ],
-          [2, "_leftOf", 1, ["Integration Specialist", "Tokyo"]],
+          [2, "_leftOf", 0, ["Rhona Davidson", "Integration Specialist"]],
+          [1, "_leftOf", 1, ["Integration Specialist"]],
           [3, "_rightOf", 0, ["55", "2010/10/14", "$327,900"]],
           [2, "_rightOf", 1, ["2010/10/14", "$327,900"]],
           [
-            6,
+            5,
             "_leftOrRightOf",
             0,
             [
               "Rhona Davidson",
               "Integration Specialist",
-              "Tokyo",
               "55",
               "2010/10/14",
               "$327,900",
             ],
           ],
           [
-            5,
+            4,
             "_leftOrRightOf",
             1,
-            ["Integration Specialist", "Tokyo", "55", "2010/10/14", "$327,900"],
+            ["Integration Specialist", "55", "2010/10/14", "$327,900"],
           ],
           [1, "_above", 0, ["San Francisco"]],
           [2, "_under", 0, ["New York", "San Francisco"]],

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-api.function.spec.ts
@@ -218,6 +218,50 @@ describe("relations-api", () => {
         });
       });
 
+      describe("horizontal", () => {
+        beforeAll(async () => {
+          await driver.get(
+            mockHtml(`
+                <table>
+                    <tr>
+                        <td>left</td>
+                        <td><div id="anchor">center</div></td>
+                        <td>right</td>
+                    </tr>
+                </table>
+                `)
+          );
+        });
+
+        it("should find element with _leftOf", async () => {
+          const anchor = await createQuery(By.css("#anchor"));
+          const leftQuery = await api._leftOf(anchor)(
+            createCssQuery(By.css("code"))
+          );
+          const left = await accessorUtil.fetchElements(leftQuery);
+          expect(left.length).toBe(1);
+        });
+
+        it("should find element with _rightOf", async () => {
+          const anchor = await createQuery(By.css("#anchor"));
+          const leftQuery = await api._rightOf(anchor)(
+            createCssQuery(By.css("code"))
+          );
+          const right = await accessorUtil.fetchElements(leftQuery);
+          expect(right.length).toBe(1);
+        });
+
+        it("should find element with _leftOrRight", async () => {
+          const anchor = await createQuery(By.css("#anchor"));
+          const leftQuery = await api._leftOrRightOf(
+            anchor,
+            0
+          )(createCssQuery(By.css("code")));
+          const leftOrRight = await accessorUtil.fetchElements(leftQuery);
+          expect(leftOrRight.length).toBe(1);
+        });
+      });
+
       describe("position", () => {
         beforeAll(async () => {
           await driver.get(

--- a/packages/sakuli-legacy/src/context/sahi/relations/vector2.type.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/vector2.type.spec.ts
@@ -1,0 +1,34 @@
+import { isInVector, isLeftOf, isRightOf, Vector2 } from "./vector2.type";
+
+describe("vector2", () => {
+  const v1: Vector2 = [1, 2];
+  const v2: Vector2 = [3, 4];
+  describe("isLeftOf", () => {
+    it("should indicate, that v1 is left of v2", () => {
+      expect(isLeftOf(v2, v1)).toBe(true);
+    });
+    it("should indicate, that v2 is not left of v1", () => {
+      expect(isLeftOf(v1, v2)).toBe(false);
+    });
+  });
+  describe("isRightOf", () => {
+    it("should indicate, that v1 is not right of v2", () => {
+      expect(isRightOf(v2, v1)).toBe(false);
+    });
+    it("should indicate, that v2 is right of v1", () => {
+      expect(isRightOf(v1, v2)).toBe(true);
+    });
+  });
+  describe("isInVector", () => {
+    const range: Vector2 = [2, 4];
+    it("should indicate, that 3 is in vector range", () => {
+      expect(isInVector(3, range)).toBe(true);
+    });
+    it("should indicate, that 5 is not in vector range", () => {
+      expect(isInVector(5, range)).toBe(false);
+    });
+    it("should indicate, that 1 is not in vector range", () => {
+      expect(isInVector(1, range)).toBe(false);
+    });
+  });
+});

--- a/packages/sakuli-legacy/src/context/sahi/relations/vector2.type.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/vector2.type.ts
@@ -10,7 +10,7 @@ export function vectorAdd([x1, y1]: Vector2, [x2, y2]: Vector2): Vector2 {
  * @param v2 Vector2
  */
 export function isLeftOf([x1]: Vector2, [x2]: Vector2) {
-  return x1 >= x2;
+  return x1 > x2;
 }
 
 /**


### PR DESCRIPTION
_rightOf fetches the anchors own ancestors, even if their center is exactly in the same horizontal position (center has the same x value).
Is this intended behaviour?