### PR TITLE
Enhancement/599/improve logging for fetch elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Bugfix: Dynamic wait not initialised, reason: NoSuchSessionError [(#583)](https://github.com/sakuli/sakuli/issues/583)
 - Enhancement: Require compatible Node engine Version in package.json [(#589)](https://github.com/sakuli/sakuli/issues/589)
 - Enhancement: Sakuli CLl encrypt command fails when secret is a numerical value [(#587)](https://github.com/sakuli/sakuli/issues/587)
+- Enhancement: Improve logging for fetchElements [(#599)](https://github.com/sakuli/sakuli/issues/599)
 
 ## v2.4.0
 

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
@@ -246,7 +246,7 @@ describe("AccessorUtil", () => {
           identifier: "D1[1]",
           relations: [],
         });
-        expect(testExecutionContext.logger.debug).toHaveBeenCalledTimes(2);
+        expect(testExecutionContext.logger.debug).toHaveBeenCalledTimes(3);
         return expect(div.getAttribute("id")).resolves.toBe("div-2");
       });
 

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.spec.ts
@@ -1,10 +1,25 @@
 import { By, ThenableWebDriver, WebElement } from "selenium-webdriver";
-import { createTestEnv, mockHtml, TestEnvironment } from "../__mocks__";
+import {
+  createTestEnv,
+  getTestBrowserList,
+  mockHtml,
+  TestEnvironment,
+} from "../__mocks__";
 import { createTestExecutionContextMock } from "../../__mocks__";
 import { AccessorUtil } from "./accessor-util.class";
 import { RelationsResolver } from "../relations";
 import { TestExecutionContext } from "@sakuli/core";
-import { getTestBrowserList } from "../__mocks__/get-browser-list.function";
+import { sahiQueryToString } from "../sahi-element-utils";
+
+jest.mock("../sahi-element-utils", () => {
+  const originalModule = jest.requireActual("../sahi-element-utils");
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    sahiQueryToString: jest.fn(),
+  };
+});
 
 jest.setTimeout(15_000);
 describe("AccessorUtil", () => {
@@ -28,6 +43,7 @@ describe("AccessorUtil", () => {
           testExecutionContext,
           new RelationsResolver(driver, testExecutionContext)
         );
+        jest.clearAllMocks();
       });
 
       afterAll(async () => {
@@ -234,6 +250,7 @@ describe("AccessorUtil", () => {
       });
 
       it("should identify an element by string index", async () => {
+        //GIVEN
         await driver.get(
           mockHtml(`
             <div id="div-1">D1</div>
@@ -241,12 +258,34 @@ describe("AccessorUtil", () => {
             <div id="div-3">D1</div>
         `)
         );
-        const div = await accessorUtil.fetchElement({
+        const query = {
           locator: By.css("div"),
           identifier: "D1[1]",
           relations: [],
+        };
+        const queryString = "mock sahi query";
+        (<jest.Mock>sahiQueryToString).mockImplementation(() => {
+          return queryString;
         });
-        expect(testExecutionContext.logger.debug).toHaveBeenCalledTimes(3);
+
+        //WHEN
+        const div = await accessorUtil.fetchElement(query);
+
+        //THEN
+        expect(testExecutionContext.logger.debug).toHaveBeenNthCalledWith(
+          1,
+          "1 Elements found for query",
+          queryString
+        );
+        expect(testExecutionContext.logger.trace).toHaveBeenNthCalledWith(
+          1,
+          "Fetch Element",
+          queryString
+        );
+        expect(testExecutionContext.logger.trace).toHaveBeenNthCalledWith(
+          2,
+          `3 Elements found with locator ${query.locator}`
+        );
         return expect(div.getAttribute("id")).resolves.toBe("div-2");
       });
 

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -269,13 +269,18 @@ export class AccessorUtil {
   }
 
   async fetchElement(
-    query: SahiElementQueryOrWebElement | WebElement,
+    query: SahiElementQueryOrWebElement,
     waitTimeout: number = this.timeout
   ): Promise<WebElement> {
-    this.testExecutionContext.logger.trace("Fetch Element", query);
-    return isSahiElementQuery(query)
-      ? this.fetchElements(query, waitTimeout).then(([first]) => first)
-      : Promise.resolve(query);
+    if (isSahiElementQuery(query)) {
+      this.testExecutionContext.logger.trace(
+        "Fetch Element",
+        sahiQueryToString(query)
+      );
+      return this.fetchElements(query, waitTimeout).then(([first]) => first);
+    } else {
+      return Promise.resolve(query);
+    }
   }
 
   private isRegExpString(identifier: string) {

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -247,14 +247,15 @@ export class AccessorUtil {
     waitTimeout: number = this.timeout
   ): Promise<WebElement> {
     if (isSahiElementQuery(query)) {
+      const stringifiedQuery = sahiQueryToString(query)
       this.testExecutionContext.logger.trace(
         "Fetch Element",
-        sahiQueryToString(query)
+        stringifiedQuery
       );
       const elements = await this.fetchElements(query, waitTimeout);
       this.testExecutionContext.logger.debug(
         `${elements.length} Elements found for query`,
-        sahiQueryToString(query)
+        stringifiedQuery
       );
       return elements[0];
     } else {

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -236,9 +236,6 @@ export class AccessorUtil {
   ): Promise<WebElement[]> {
     return this.webDriver.wait<WebElement[]>(
       async () => {
-        this.testExecutionContext.logger.trace(
-          "Start applying relations to element"
-        );
         const queryAfterRelation = await this.relationResolver.applyRelations(
           query
         );

--- a/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/accessor/accessor-util.class.ts
@@ -209,7 +209,7 @@ export class AccessorUtil {
     }
     if (typeof identifier === "number") {
       this.testExecutionContext.logger.trace(
-        `Resolve identifier as Sahi index ${identifier}`
+        `Resolve identifier as index reference ${identifier}`
       );
       return Promise.resolve([
         this.getElementBySahiIndex(elements, { sahiIndex: identifier }),

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-resolver.class.spec.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-resolver.class.spec.ts
@@ -4,6 +4,7 @@ import { TestExecutionContext } from "@sakuli/core";
 import { RelationsResolver } from "./relations-resolver.class";
 import { createTestEnv, mockHtml, TestEnvironment } from "../__mocks__";
 import { getTestBrowserList } from "../__mocks__/get-browser-list.function";
+import { SimpleLogger } from "@sakuli/commons";
 
 const webElementToQuery = (elements: WebElement[]) => {
   return {
@@ -18,7 +19,11 @@ describe("RelationResolver", () => {
   describe.each(getTestBrowserList())(
     "%s",
     (browser: "firefox" | "chrome", local: boolean) => {
-      const testExecutionContext = mockPartial<TestExecutionContext>({});
+      const testExecutionContext = mockPartial<TestExecutionContext>({
+        logger: mockPartial<SimpleLogger>({
+          trace: jest.fn(),
+        }),
+      });
 
       let env: TestEnvironment;
       beforeAll(async () => {

--- a/packages/sakuli-legacy/src/context/sahi/relations/relations-resolver.class.ts
+++ b/packages/sakuli-legacy/src/context/sahi/relations/relations-resolver.class.ts
@@ -2,6 +2,7 @@ import { ThenableWebDriver } from "selenium-webdriver";
 import { TestExecutionContext } from "@sakuli/core";
 import { SahiRelation } from "./sahi-relation.interface";
 import { SahiElementQuery } from "../sahi-element.interface";
+import { sahiQueryToString } from "../sahi-element-utils";
 
 export class RelationsResolver {
   constructor(
@@ -12,7 +13,12 @@ export class RelationsResolver {
   applyRelations(elementsQuery: SahiElementQuery): Promise<SahiElementQuery> {
     return elementsQuery.relations.reduce(
       async (last: Promise<SahiElementQuery>, relation: SahiRelation) => {
-        return await relation(await last);
+        const lastElement = await last;
+        this.testExecutionContext.logger.trace(
+          `Start applying relation to element`,
+          sahiQueryToString(lastElement)
+        );
+        return await relation(lastElement);
       },
       Promise.resolve(elementsQuery)
     );


### PR DESCRIPTION
I'm not too sure if the log output handling or the log output itself in `fetchElement` is nice but when a relation is used a query is returned with literally no information except an anonymous function as the locator, e.g.
```
[Wed Feb 03 2021 10:07:44 GMT+0100 (Central European Standard Time)] TRACE: Created query after applying relation {"relations":[],"identifier":{}}
[Wed Feb 03 2021 10:07:44 GMT+0100 (Central European Standard Time)] TRACE: 1 Elements found function(driver) {
      return driver.executeScript.apply(driver, args);
    }
```


Closes #599 